### PR TITLE
nested array of layers is not compliant with mapboxgl specification

### DIFF
--- a/bridgestyle/mapboxgl/fromgeostyler.py
+++ b/bridgestyle/mapboxgl/fromgeostyler.py
@@ -29,7 +29,7 @@ def processLayer(layer):
     
     for rule in layer["rules"]:
         layers = processRule(rule, layer["name"])
-        allLayers.append(layers)
+        allLayers += layers
 
     return allLayers
 

--- a/bridgestyle/qgis/togeostyler.py
+++ b/bridgestyle/qgis/togeostyler.py
@@ -46,7 +46,8 @@ def processLayer(layer):
                 _warnings.append("Unsupported renderer type: %s" % str(renderer))
                 return
             for rule in renderer.rootRule().children():
-                rules.append(processRule(rule))
+                if rule.active():
+                    rules.append(processRule(rule))
             labelingRule = processLabeling(layer)
             if labelingRule is not None:
                 rules.append(labelingRule)


### PR DESCRIPTION
I'm testing QGIS style conversion to mapboxgl style and I verify that layers output in json object is not compliant with mapboxgl style specification (https://docs.mapbox.com/mapbox-gl-js/style-spec/#root-layers) and the features are not displayed (using olms.js in openlayers)

You can check this running http://jsfiddle.net/enricofer/4ewvgcku/34/ 
where the style that outputs from bridgestyle.qgis.layerStyleAsMapbox is applied to a openlayers geojson file with olms.js and renders nothing without any warning or exception

Applying the provided path the result is http://jsfiddle.net/enricofer/4ewvgcku/ where the the result is exactly what expected.

...Note that optional sprite parameter has to be set to undefined for correct rendering of style. Would be better if not set unless converted style use sprites