### PR TITLE
qgis.togeostyler: QGIS line label anchor/xy offset

### DIFF
--- a/bridgestyle/qgis/togeostyler.py
+++ b/bridgestyle/qgis/togeostyler.py
@@ -177,7 +177,10 @@ def processLabeling(layer):
         symbolizer.update({"haloColor": haloColor,
                             "haloSize": haloSize})
     if layer.geometryType() == QgsWkbTypes.LineGeometry:
+        anchor = quadOffset[settings.quadOffset]
         offset = _labelingProperty(settings, None, "dist")
+        offsetX = offset
+        offsetY = offset
         symbolizer["offset"] = offset
     else:
         anchor = quadOffset[settings.quadOffset]


### PR DESCRIPTION
Fixes: #7

Not sure if this is correct, but it solves the error in my case.