### PR TITLE
checked each of the qgis symbols in geoserver

### DIFF
--- a/bridgestyle/qgis/togeostyler.py
+++ b/bridgestyle/qgis/togeostyler.py
@@ -428,20 +428,24 @@ def _basePointSimbolizer(sl, opacity):
 
     return symbolizer
 
-wknReplacements = {"regular_star":"star",
+wknReplacements = {"regularstar":"star",
                "cross2": "x",
-               "equilateral_triangle": "triangle",
                "rectangle": "square",
-               "filled_arrowhead": "ttf://Webdings#0x34",
+               "arrowhead": "shape://oarrow",
+               "filledarrowhead": "shape://coarrow",
                "line": "shape://vertline",
-               "arrow": "ttf://Wingdings#0xE9",
-               "diamond": "ttf://Wingdings#0x75",
-                "horline":"shape://horline",
-               "vertline":"shape://vertline",
-               "cross":"shape://plus",
+               "plus":"cross",
+               # somehow these marks require the shape:// prefix in geoserver
+               "oarrow": "shape://oarrow",
+               "carrow": "shape://carrow",
+               "coarrow": "shape://coarrow",
+               "ccarrow": "shape://ccarrow",
+               "vertline": "shape://vertline",
+               "horline": "shape://horline",
+               "dot":"shape://dot",
                "slash":"shape://slash",
                "backslash":"shape://backslash",
-               "x": "shape://times"}
+               "times": "shape://times"}
 
 def _markGraphic(sl):
     props = sl.properties()
@@ -457,7 +461,8 @@ def _markGraphic(sl):
         outlineStyle = "solid"
         size = _symbolProperty(sl, "size", QgsSymbolLayer.PropertyWidth)
     except:
-        name = props["name"]
+        #qgis uses internally a underscore notation for marks
+        name = props["name"].replace("_","") 
         name = wknReplacements.get(name, name)
         outlineStyle = _symbolProperty(sl, "outline_style", QgsSymbolLayer.PropertyStrokeStyle)
         if outlineStyle == "no":

--- a/bridgestyle/qgis/togeostyler.py
+++ b/bridgestyle/qgis/togeostyler.py
@@ -430,6 +430,7 @@ def _basePointSimbolizer(sl, opacity):
 
 wknReplacements = {"regularstar":"star",
                "cross2": "x",
+               "equilateral_triangle": "triangle",
                "rectangle": "square",
                "arrowhead": "shape://oarrow",
                "filledarrowhead": "shape://coarrow",
@@ -442,9 +443,9 @@ wknReplacements = {"regularstar":"star",
                "ccarrow": "shape://ccarrow",
                "vertline": "shape://vertline",
                "horline": "shape://horline",
-               "dot":"shape://dot",
-               "slash":"shape://slash",
-               "backslash":"shape://backslash",
+               "dot": "shape://dot",
+               "slash": "shape://slash",
+               "backslash": "shape://backslash",
                "times": "shape://times"}
 
 def _markGraphic(sl):


### PR DESCRIPTION
fixes #16 
removes the underscores from style names
adding shape:// prefix for some symbols may cause issues if people want to use the sld in qgis or deegree
also removed references to wingdings font, that font is not available on linux systems (these marks are now available in geoserver)