### PR TITLE
fix min/max scale and add in support for IN ops

### DIFF
--- a/bridgestyle/qgis/togeostyler.py
+++ b/bridgestyle/qgis/togeostyler.py
@@ -252,8 +252,10 @@ def processRule(rule):
         return [ruledef]
 
 def processRuleScale(rule):
-    return {"min": rule.minimumScale(),
-            "max": rule.maximumScale()}
+    # in QGIS, minimumScale() is a large number (i.e. very zoomed out).
+    # however, these are backwards if you think in terms of RF.
+    return {"max": rule.minimumScale(),
+            "min": rule.maximumScale()}
 
 def processExpression(expstr):
     try:

--- a/bridgestyle/sld/fromgeostyler.py
+++ b/bridgestyle/sld/fromgeostyler.py
@@ -49,10 +49,10 @@ def processRule(rule):
         scale = rule["scaleDenominator"]
         if "max" in scale:
             maxScale = SubElement(ruleElement, "MaxScaleDenominator")
-            maxScale.text = scale["max"]
+            maxScale.text = str(scale["max"])
         if "min" in scale:
             minScale = SubElement(ruleElement, "MinScaleDenominator")
-            maxScale.text = scale["min"]
+            minScale.text = str(scale["min"])
     ruleFilter = rule.get("filter", None)
     if ruleFilter == "ELSE":
         filterElement = Element("ElseFilter")            


### PR DESCRIPTION
min/max style;

a) for the actual scale denominator, it was using the float value (xml#text requires string).  Converted float->string
b) it was using maxScale for both the min max 
c) I change the qgis side because there's confusion for scale WRT min/max.
    SLD -> based on the RF denominator (so larger -> zoomed out)
    QGS -> based on the RF (so larger -> zoomed in)
   Fixed

Also, added support for IN op.  
I originally did this by constructing a new QgsExpression that represented the ((A='a') OR (A='b')) format.  However, this caused memory issues (QGIS hard crash), so i did it without creating any QGS objects.