### PR TITLE
Handle MBGLJS perpendicular offset

### DIFF
--- a/bridgestyle/mapboxgl/fromgeostyler.py
+++ b/bridgestyle/mapboxgl/fromgeostyler.py
@@ -204,14 +204,14 @@ def _textSymbolizer(sl):
     fontFamily = _symbolProperty(sl, "font")
     label = _symbolProperty(sl, "label")
     size = _symbolProperty(sl, "size")
-    if "offset" in sl:
+    if "perpendicularOffset" in sl:
+        offset = sl["perpendicularOffset"]
+        layout["text-offset"] = offset
+    elif "offset" in sl:
         offset = sl["offset"]
         offsetx = convertExpression(offset[0])
         offsety = convertExpression(offset[1])
         layout["text-offset"] = [offsetx, offsety]
-    elif "perpendicularOffset" in sl:
-        offset = sl["perpendicularOffset"]
-        layout["text-offset"] = offset
 
     if "haloColor" in sl and "haloSize" in sl:
         paint["text-halo-width"] = _symbolProperty(sl, "haloSize")


### PR DESCRIPTION
Seems to fail with QGIS labelled line (default settings) exported to Geostyler > MBGLJS. This fix assumes that Geostyler text symbolizer definitions with `perpendicularOffset` are more specific than those with `offset`, so reversing the `if...else` fixes it. It works for me, but the bug needs to be confirmed by someone (as does the fix, obviously).