### PR TITLE
remove processTextSymbolizer switch from mapbox/maplibre, fix #67

### DIFF
--- a/bridgestyle/mapboxgl/fromgeostyler.py
+++ b/bridgestyle/mapboxgl/fromgeostyler.py
@@ -13,7 +13,6 @@ from ..qgis.expressions import (
 
 # Globals
 _warnings = []
-_processTextSymbolizer = False
 
 # Constants
 SOURCE_NAME = "vector-source"
@@ -284,8 +283,6 @@ def _symbolProperty(sl, name, default=None):
 
 
 def _textSymbolizer(sl):
-    if not _processTextSymbolizer:
-        return None
     layout = {}
     paint = {}
     color = _symbolProperty(sl, "color")


### PR DESCRIPTION
There doesn't seem to be a clear reason to keep it in or make it configurable, so removing it.