### PR TITLE
map QGIS string and number field types to Maplibre expressions

### DIFF
--- a/bridgestyle/mapboxgl/fromgeostyler.py
+++ b/bridgestyle/mapboxgl/fromgeostyler.py
@@ -220,7 +220,9 @@ func = {
     "log": "ln",
     "strCapitalize": None,
     "min": "min",
-    "max": "max"
+    "max": "max",
+    "to-number": "to-number",
+    "to-string": "to-string",
 }  # TODO
 
 


### PR DESCRIPTION
fix #77

Note: QGIS field type names depend on the data source and the casting done in this commit works for Geopackage/Sqlite (String, Integer, Integer64 and Real; see https://github.com/geraldo/bridge-style/commit/53bcd4c489ef08a8cea3e16ec63c108d3986dd58#diff-a005892a195c40f50d63aac1563a58c47a23b11fa2e96be830741ccc775b7c1cR113). Probably these castings have to be extended in order to make it work with other data sources.