### PR TITLE
to_float should be to_real

### DIFF
--- a/bridgestyle/qgis/expressions.py
+++ b/bridgestyle/qgis/expressions.py
@@ -111,7 +111,7 @@ functions = {
     "min": "min",
     "max": "max",
     "to_int": "parseLong",
-    "to_float": "parseDouble",
+    "to_real": "parseDouble",
     "to_string": "to_string",  # Not mapped to function, but required by MapBox GL
 }  # TODO: test/improve
 


### PR DESCRIPTION
Seems that the function you named does not exist, @geraldo.
You added `to_float` to `expressions.py`, but it's supposed to be [`to_real`](https://docs.qgis.org/3.34/en/docs/user_manual/expressions/functions_list.html#to-real), I think.

This fixes that.