### PR TITLE
Fix mark symbolizer with sprites

### DIFF
--- a/bridgestyle/mapboxgl/fromgeostyler.py
+++ b/bridgestyle/mapboxgl/fromgeostyler.py
@@ -400,7 +400,7 @@ def _iconSymbolizer(sl):
 
 
 def _markSymbolizer(sl):
-    shape = sl.get('shape')
+    shape = sl.get('wellKnownName')
     if shape != None and shape.startswith("file://"):
         svgFilename = shape.split("//")[-1]
         name = os.path.splitext(svgFilename)[0]


### PR DESCRIPTION
Thanks for open-sourcing this great library. I was playing with the different options of the QGIS -> Mapbox GL converter and I found that many things are just supported out-of-the box. Only there was one thing I got stuck on, which is the conversion of QGIS vector symbology using SVG files as sprites.

With this small script, executed in the QGIS Interpreter I was able to export the style JSON and sprite sheet:

```python
import bridgestyle
from pathlib importy Path

group = {"layers": ["points"]}
qgis_layers = {x.name(): x for x in iface.layerTreeView().selectedLayers()}
baseUrl = "http://testserver"
workspace = "workspace"
name = "points"

_, warnings, mb_style, sprite_sheet = bridgestyle.mapboxgl.fromgeostyler.convertGroup(group, qgis_layers, baseUrl, workspace, name)

path = Path("/some/local/path/to/export")


json.dump(mb_style, open(path / "style.json", "w"))
sprite_sheet["img"].save(str(path / "sprite.png"), "png")
sprite_sheet["img2x"].save(str(path / "sprite@2x.png"), "png")
(path / "sprite.json").write_text(sprite_sheet["json"])
(path / "sprite@2x.json").write_text(sprite_sheet["json2x"])
```

Only I found that the `style.json` did not reference any of the sprites. Instead it had standard "circle" properties in the layer "paint" field (see JSON below). I traced the issue to the line in this PR. The Geostyler spec doesn't have any `shape` in its [MarkSymbolizer](https://geostyler.github.io/geostyler-style/docs/master/interfaces/MarkSymbolizer.html), so this line seems to be plainly wrong. Changing it to `wellKnownName` fixed the issue and indeed I now get a proper reference to the sprite in the exported style JSON (see below).

The simplified style JSON file, produced by master:

<details>

```json
{
    "version": 8,
    "glyphs": "mapbox://fonts/mapbox/{fontstack}/{range}.pbf",
    "name": "points",
    "sources": {
        "vector-source": {
            "type": "vector",
            "tiles": [
                "..."
            ],
            "minZoom": 0,
            "maxZoom": 20
        }
    },
    "sprite": "http://testserver/styles/workspace/spriteSheet",
    "layers": [
        {
            "type": "circle",
            "paint": {
                "circle-radius": [
                    "/",
                    35.71428571428571,
                    2
                ],
                "circle-color": "#232323",
                "circle-opacity": 1.0,
                "circle-stroke-width": 0.7142857142857143,
                "circle-stroke-color": "#232323"
            },
            "source": "vector-source",
            "source-layer": "points",
            "id": "points:(rule#0):0"
        }

}
```

</details>

The simplified style JSON file, produced by my branch:

<details>

```json
{
    "version": 8,
    "glyphs": "mapbox://fonts/mapbox/{fontstack}/{range}.pbf",
    "name": "points",
    "sources": {
        "vector-source": {
            "type": "vector",
            "tiles": [
                "..."
            ],
            "minZoom": 0,
            "maxZoom": 20
        }
    },
    "sprite": "http://testserver/styles/workspace/spriteSheet",
    "layers": [
        {
            "type": "symbol",
            "layout": {
                "icon-image": "accommodation_bed_and_breakfast",
                "icon-rotate": 0.0,
                "icon-size": 0.5580357142857142
            },
            "source": "vector-source",
            "source-layer": "points",
            "id": "points:(rule#0):0"
        }]
}
```

</details>

The geostyler symbolizer (it has no "shape" field indeed):

<details>

```json
 {
                    "opacity": 1.0,
                    "rotate": 0.0,
                    "color": "#232323",
                    "kind": "Mark",
                    "wellKnownName": "file://accommodation_bed_and_breakfast.svg",
                    "size": 35.71428571428571,
                    "strokeColor": "#232323",
                    "strokeWidth": 0.7142857142857143,
                    "strokeOpacity": 1.0,
                    "fillOpacity": 1.0,
                    "spriteName": "accommodation_bed_and_breakfast.svg",
                    "Z": 0
                }
            
```

</details>