### PR TITLE
Fix processLayer method when renderer is None

### DIFF
--- a/bridgestyle/qgis/togeostyler.py
+++ b/bridgestyle/qgis/togeostyler.py
@@ -83,6 +83,9 @@ def processLayer(layer):
     if layer.type() == layer.VectorLayer:
         rules = []
         renderer = layer.renderer()
+        if renderer is None:
+            _warnings.append("No renderer found for layer: %s" % layer.name())
+            return
         if isinstance(renderer, QgsHeatmapRenderer):
             symbolizer, transformation = heatmapRenderer(renderer)
             if symbolizer and transformation:


### PR DESCRIPTION
In my project, there are some vector layers that don't have a renderer. In this case, it crashes and exits QGIS completely. I added a check for when renderer is None in the `processLayer` method. This helps to prevent the crash and the `convert` method can then be executed successfully.

This is the stack trace:

> ## Report Details
> 
> **Python Stack Trace**
> Windows fatal exception: access violation
> 
> Current thread 0x000014e0 (most recent call first):
>   File "C:\Users\hoan.phung\AppData\Roaming\Rana\QGIS3\profiles\default/python/plugins\rana_qgis_plugin\libs\bridgestyle\qgis\togeostyler.py", line 95 in processLayer
>     ruleRenderer = QgsRuleBasedRenderer.convertFromRenderer(
>   File "C:\Users\hoan.phung\AppData\Roaming\Rana\QGIS3\profiles\default/python/plugins\rana_qgis_plugin\libs\bridgestyle\qgis\togeostyler.py", line 70 in convert
>     geostyler = processLayer(layer)
>   File "C:\Users\hoan.phung\AppData\Roaming\Rana\QGIS3\profiles\default/python/plugins\rana_qgis_plugin\libs\bridgestyle\mapboxgl\fromgeostyler.py", line 50 in convertGroup
>     geostyler, icons, sprites, warnings = qgis2geostyler.convert(layer)
>   File "C:\Users\hoan.phung\AppData\Roaming\Rana\QGIS3\profiles\default/python/plugins\rana_qgis_plugin\workers.py", line 183 in run
>     _, warning, mb_style, sprite_sheet = convertGroup(
> 
> Thread 0x00001adc (most recent call first):
>   <no Python frame>
> 
> 
> 
> **Stack Trace**
> 
> QBitArray::QBitArray :
> QgsRuleBasedRenderer::convertFromRenderer :
> pdal::PointView::layout :
> PyLong_FromString :
> PyObject_Vectorcall :
> PyObject_Vectorcall :
> PyEval_EvalFrameDefault :
> PyFunction_Vectorcall :
> PyArg_CheckPositional :
> PyObject_Call :
> PyObject_Call :
> PyInit_sip :
> PyInit_sip :
> PyInit_QtCore :
> QThread::start :
> BaseThreadInitThunk :
> RtlUserThreadStart :
> 
> 
> 
> 
> **QGIS Info**
> QGIS Version: 3.40.2-Bratislava
> QGIS code revision: 14826ca1
> Compiled against Qt: 5.15.13
> Running against Qt: 5.15.13
> Compiled against GDAL: 3.9.3
> Running against GDAL: 3.9.3
> 
> 
> 
> **System Info**
> CPU Type: x86_64
> Kernel Type: winnt
> Kernel Version: 10.0.17763