### PR TITLE
Remove file extension from name in sprite.json

### DIFF
--- a/bridgestyle/mapboxgl/fromgeostyler.py
+++ b/bridgestyle/mapboxgl/fromgeostyler.py
@@ -71,9 +71,10 @@ def toSpriteSheet(allSprites):
     img, img2x, painter, painter2x, spritesheet, spritesheet2x = qgis2geostyler.initSpriteSheet(width, height)
     x = 0
     for name, _sprites in allSprites.items():
+        name_without_ext = os.path.splitext(name)[0]
         s = _sprites["image"]
         s2x = _sprites["image2x"]
-        qgis2geostyler.drawSpriteSheet(name, painter, painter2x, spritesheet, spritesheet2x, x, s, s2x)
+        qgis2geostyler.drawSpriteSheet(name_without_ext, painter, painter2x, spritesheet, spritesheet2x, x, s, s2x)
         x += s.width()
     painter.end()
     painter2x.end()


### PR DESCRIPTION
Currently, there is a difference in the **style.json** and **sprite.json**. The name key in style json is without the file extension while the sprite json contains the file extension.

For example:

in style.json: the name is `accommodation_bed_and_breakfast`
in sprite.json: the name is `accommodation_bed_and_breakfast.svg`

Due to this, the icons cannot be displayed on the map in Maplibre.