### PR TITLE
Fix simple markers not being converted but only svg markers

### DIFF
--- a/bridgestyle/mapboxgl/fromgeostyler.py
+++ b/bridgestyle/mapboxgl/fromgeostyler.py
@@ -401,9 +401,8 @@ def _iconSymbolizer(sl):
 
 def _markSymbolizer(sl):
     shape = sl.get('wellKnownName')
-    if shape != None and shape.startswith("file://"):
-        svgFilename = shape.split("//")[-1]
-        name = os.path.splitext(svgFilename)[0]
+    if shape != None and shape != "circle":
+        name = os.path.splitext(shape)[0]
         rotation = _symbolProperty(sl, "rotate")
         size = _symbolProperty(sl, "size", 16) / 64.0
 

--- a/bridgestyle/qgis/togeostyler.py
+++ b/bridgestyle/qgis/togeostyler.py
@@ -783,10 +783,10 @@ def _markGraphic(sl):
     spriteName = ""
     try:
         path = sl.path()
-        spriteName = os.path.basename(path)
+        name = os.path.basename(path)
+        spriteName = name.replace(":", "_").replace("/", "_")
         _usedIcons[sl.path()] = sl
         _usedSprites[spriteName] = _createSprite(sl)
-        name = "file://" + os.path.basename(path)
         outlineStyle = "solid"
         size = _symbolProperty(sl, "size", QgsSymbolLayer.PropertyWidth)
     except:
@@ -797,8 +797,6 @@ def _markGraphic(sl):
         if outlineStyle == "no":
             outlineWidth = 0
         spriteName = name.replace(":", "_").replace("/", "_")
-        spriteName = spriteName + "-{0}-{1}-{2}-{3}-{4}" \
-            .format(color, fillOpacity, outlineColor, strokeOpacity, outlineWidth)
         _usedSprites[spriteName] = _createSprite(sl)
 
     mark = {"kind": "Mark",


### PR DESCRIPTION
Currently, only SVG markers are converted and included correctly in the style.json file when converting to Mapbox GL style. Simple markers are ignored and being converted to the default "circle" layer.

Due to this, simple markers are only displayed as circles in Maplibre / Mapbox.

This PR fixed the issue and both simple and SVG markers are now shown correctly on the maplibre / mapbox map.