### PR TITLE
Lyrx improvements: fills and symbols along line

### DIFF
--- a/src/bridgestyle/arcgis/togeostyler.py
+++ b/src/bridgestyle/arcgis/togeostyler.py
@@ -398,13 +398,13 @@ def processSymbolReference(symbolref, options):
                 # Functions "xyzPoint" and "xyzAngle" are not supported in the legend in GeoServer,
                 # so we include this symbol only on the map and not in the legend (using inclusion: "mapOnly")
                 if layer["type"] == "CIMCharacterMarker" and _orientedMarkerAtRatioOfLine(layer["markerPlacement"], 1):
-                    symbolizer = _processOrientedMarkerAtFunctionfLine(layer, "end", options)
+                    symbolizer = _processOrientedMarkerAtFunctionOfLine(layer, "end", options)
                     symbolizer["inclusion"] = "mapOnly"
                 elif layer["type"] == "CIMCharacterMarker" and _orientedMarkerAtRatioOfLine(layer["markerPlacement"], 0.5):
-                    symbolizer = _processOrientedMarkerAtFunctionfLine(layer, "mid", options)
+                    symbolizer = _processOrientedMarkerAtFunctionOfLine(layer, "mid", options)
                     symbolizer["inclusion"] = "mapOnly"
                 elif layer["type"] == "CIMCharacterMarker" and _orientedMarkerAtRatioOfLine(layer["markerPlacement"], 0):
-                    symbolizer = _processOrientedMarkerAtFunctionfLine(layer, "start", options)
+                    symbolizer = _processOrientedMarkerAtFunctionOfLine(layer, "start", options)
                     symbolizer["inclusion"] = "mapOnly"
                 else:
                     symbolizer = _formatLineSymbolizer(symbolizer)
@@ -448,7 +448,7 @@ def _formatPolygonSymbolizer(symbolizer, markerPlacement):
         }
     return symbolizer
 
-def _processOrientedMarkerAtFunctionfLine(layer, functionPrefix, options):
+def _processOrientedMarkerAtFunctionOfLine(layer, functionPrefix, options):
     replaceesri = options.get("replaceesri", False)
     fontFamily = layer["fontFamilyName"]
     charindex = layer["characterIndex"]
@@ -748,10 +748,10 @@ def processSymbolLayer(layer, symboltype, options):
         size = _ptToPxProp(layer, "separation", 3)
         symbolLayers = layer["lineSymbol"]["symbolLayers"]
         color, width = _extractStroke(symbolLayers)
-        wellKnowName = _hatchMarkerForAngle(rotation)
+        wellKnownName = _hatchMarkerForAngle(rotation)
         # separation is distance between lines, for diagonal lines, it is along the orthogonal axis,
         # so we need to multiply it by sqrt(2) to get the size of the separation
-        if "slash" in wellKnowName:
+        if "slash" in wellKnownName:
             size = size * math.sqrt(2)
         offset = _extractOffset(layer)
         fill = {
@@ -761,7 +761,7 @@ def processSymbolLayer(layer, symboltype, options):
                 {
                     "kind": "Mark",
                     "color": color,
-                    "wellKnownName": wellKnowName,
+                    "wellKnownName": wellKnownName,
                     "size": size,
                     "strokeColor": color,
                     "strokeWidth": width,
@@ -777,10 +777,10 @@ def processSymbolLayer(layer, symboltype, options):
             fill["graphicFill"][0]["outlineDasharray"] = effects["dasharray"]
             # In case of dash array, the size must be at least as long as the dash pattern sum.
             neededSize = sum(effects["dasharrayValues"])
-            if wellKnowName in _getStraightHatchMarker():
+            if wellKnownName in _getStraightHatchMarker():
                 # To keep the "original size", we play with a negative margin
                 negativeMargin = (neededSize - size) / 2 * -1
-                if wellKnowName == _getStraightHatchMarker()[0]:
+                if wellKnownName == _getStraightHatchMarker()[0]:
                     fill['graphicFillMargin'] = [negativeMargin, 0, negativeMargin, 0]
                 else:
                     fill['graphicFillMargin'] = [0, negativeMargin, 0, negativeMargin]

--- a/src/bridgestyle/arcgis/togeostyler.py
+++ b/src/bridgestyle/arcgis/togeostyler.py
@@ -764,15 +764,33 @@ def processSymbolLayer(layer, symboltype, options):
 
         rotate = layer.get("rotation", 0)
         size = _ptToPxProp(layer, "height", _ptToPxProp(layer, "size", 0))
-        return {
-            "opacity": 1.0,
-            "rotate": 0.0,
-            "kind": "Icon",
-            "color": None,
-            "image": url,
-            "size": size,
-            "Z": 0,
-        }
+        if layer["type"] == "CIMPictureFill":
+            return {
+                "kind": "Fill",
+                "opacity": 1.0,
+                "graphicFill": [
+                    {
+                        "opacity": 1.0,
+                        "rotate": 0.0,
+                        "kind": "Icon",
+                        "color": None,
+                        "image": url,
+                        "size": size,
+                        "Z": 0,
+                    }
+                ],
+                "Z": 0,
+                }
+        else:
+            return {
+                "opacity": 1.0,
+                "rotate": 0.0,
+                "kind": "Icon",
+                "color": None,
+                "image": url,
+                "size": size,
+                "Z": 0,
+            }
     else:
         return None
 

--- a/src/bridgestyle/arcgis/togeostyler.py
+++ b/src/bridgestyle/arcgis/togeostyler.py
@@ -706,6 +706,11 @@ def processSymbolLayer(layer, symboltype, options):
         symbolLayers = layer["lineSymbol"]["symbolLayers"]
         color, width = _extractStroke(symbolLayers)
         wellKnowName = _hatchMarkerForAngle(rotation)
+        # separation is distance between lines, for diagonal lines, it is along the orthogonal axis,
+        # so we need to multiply it by sqrt(2) to get the size of the separation
+        if "slash" in wellKnowName:
+            size = size * math.sqrt(2)
+        offset = _extractOffset(layer)
         fill = {
             "kind": "Fill",
             "opacity": 1.0,
@@ -718,6 +723,7 @@ def processSymbolLayer(layer, symboltype, options):
                     "strokeColor": color,
                     "strokeWidth": width,
                     "rotate": 0,
+                    "offset": offset
                 }
             ],
             "Z": 0,
@@ -817,10 +823,11 @@ def _orientedMarkerAtEndOfLine(markerPlacement):
 
 
 def _extractOffset(symbolLayer):
-    # Arcgis looks to apply a strange factor.
+    # Offsets in ArcGIS are in points, but we need them in pixels. Also, they are orientated same as in SLD
+    # (x points to the right, y points up). Finally, Arcgis looks to apply a strange factor.
     offset_x = _ptToPxProp(symbolLayer, "offsetX", 0) * OFFSET_FACTOR
-    offset_y = _ptToPxProp(symbolLayer, "offsetY", 0) * OFFSET_FACTOR * -1
-    if offset_x == 0 and offset_y != 0:
+    offset_y = _ptToPxProp(symbolLayer, "offsetY", 0) * OFFSET_FACTOR
+    if offset_x == 0 and offset_y == 0:
         return None
     return [offset_x, offset_y]
 


### PR DESCRIPTION
A set of three improvements for lyrx fills:

* Add support for picture fills
* Add support for color replacement in pictures
* Add support for offsets in hatch fills

For color replacement, I found I had to write images in PNG after replacement (original was BMP) as I would otherwise had a color shift in Java. Pillow writes the BMP in BGR order but Java reads them in RGB instead.
I've tried to make the code tolerant to the absence of Pillow, it will emit a warning and avoid color replacement.

For offsets, I found that the "separation" attribute is meant orthogonally amonst the lines, so the size of the equivalent symbol needs to be adjusted for diagonal lines.

When working on offsets I found the direction of offsets in lyrx and SLD is the same... not sure why the existing code was flipping the y axis direction?

Finally, I looked at how to write tests, but did not find much an existing base, it seems there is a simple tool performing conversion and printing results? Please advise.

