### PR TITLE
mapboxgl: correct conversion for text-halo-width

### DIFF
--- a/src/bridgestyle/mapboxgl/fromgeostyler.py
+++ b/src/bridgestyle/mapboxgl/fromgeostyler.py
@@ -313,7 +313,7 @@ def _textSymbolizer(sl):
         layout["text-offset"] = [offsetx, offsety]
 
     if "haloColor" in sl and "haloSize" in sl:
-        paint["text-halo-width"] = _symbolProperty(sl, "haloSize")
+        paint["text-halo-width"] = float(_symbolProperty(sl, "haloSize"))
         paint["text-halo-color"] = _symbolProperty(sl, "haloColor")
 
     layout["text-field"] = label

--- a/src/bridgestyle/qgis/togeostyler.py
+++ b/src/bridgestyle/qgis/togeostyler.py
@@ -689,7 +689,7 @@ def _markerLineSymbolizer(sl, opacity):
     subSymbolizers = []
     for subsl in sl.subSymbol().symbolLayers():
         subSymbolizer = _createSymbolizer(subsl, 1)
-        if subSymbolizers is not None:
+        if subSymbolizer is not None:
             subSymbolizers.append(subSymbolizer)
     if subSymbolizers:
         interval = _symbolProperty(


### PR DESCRIPTION
text-halo-width needs to be a float instead of a string.

I also think the second change is related to a minor bug. I think `subSymbolizer` should be checked for `None`, not the list (`subSymbolizers`) because this will never be `None`

@GeoSander Could you have a look?