### PR TITLE
MB: Added support for atan2

### DIFF
--- a/src/bridgestyle/mapboxgl/fromgeostyler.py
+++ b/src/bridgestyle/mapboxgl/fromgeostyler.py
@@ -17,6 +17,7 @@ _warnings = []
 
 # Constants
 SOURCE_NAME = "vector-source"
+PI = 3.141592653589793
 
 
 def convertGroup(group, qgis_layers, baseUrl, workspace, name):
@@ -271,6 +272,9 @@ def convertExpression(exp):
             elif funcName == "exp":
                 # Special case to add "exp" support: replace with e^(x)
                 convertedExp = ["^", ["e"], convertExpression(exp[1])]
+            elif funcName == "atan2":
+                # Special case to replace atan2 with a piecewise function using atan.
+                convertedExp = _convertAtan2(exp)
             else:
                 convertedExp = [funcName]
                 for arg in exp[1:]:
@@ -279,6 +283,27 @@ def convertExpression(exp):
     else:
         return exp
 
+def _convertAtan2(exp):
+    # See https://en.wikipedia.org/wiki/Atan2#Definition%20and%20computation
+    # Note that the order of x and y is reversed in the definition above
+    exp_x = convertExpression(exp[2])
+    exp_y = convertExpression(exp[1])
+
+    convertedExpression = [
+        "case",
+            [">", exp_x, 0],
+                ["atan", ["/", exp_y, exp_x]],
+            ["all", ["<", exp_x, 0], [">=", exp_y, 0]],
+                ["+", ["atan", ["/", exp_y, exp_x]], PI],
+            ["all", ["<", exp_x, 0], ["<", exp_y, 0]],
+                ["-", ["atan", ["/", exp_y, exp_x]], PI],
+            ["all", ["==", exp_x, 0], [">", exp_y, 0]],
+                (PI / 2.0),
+            ["all", ["==", exp_x, 0], ["<", exp_y, 0]],
+                -(PI / 2.0),
+            0  # undefined, but we have to return something - we'll return 0
+    ]
+    return convertedExpression
 
 def processSymbolizer(sl):
     sl_type = sl.get('kind')

--- a/src/bridgestyle/mapboxgl/fromgeostyler.py
+++ b/src/bridgestyle/mapboxgl/fromgeostyler.py
@@ -18,7 +18,6 @@ _warnings = []
 
 # Constants
 SOURCE_NAME = "vector-source"
-PI = 3.141592653589793
 
 
 def convertGroup(group, qgis_layers, baseUrl, workspace, name):
@@ -299,13 +298,13 @@ def _convertAtan2(exp):
             [">", exp_x, 0],
                 ["atan", ["/", exp_y, exp_x]],
             ["all", ["<", exp_x, 0], [">=", exp_y, 0]],
-                ["+", ["atan", ["/", exp_y, exp_x]], PI],
+                ["+", ["atan", ["/", exp_y, exp_x]], math.pi],
             ["all", ["<", exp_x, 0], ["<", exp_y, 0]],
-                ["-", ["atan", ["/", exp_y, exp_x]], PI],
+                ["-", ["atan", ["/", exp_y, exp_x]], math.pi],
             ["all", ["==", exp_x, 0], [">", exp_y, 0]],
-                (PI / 2.0),
+                (math.pi / 2.0),
             ["all", ["==", exp_x, 0], ["<", exp_y, 0]],
-                -(PI / 2.0),
+                -(math.pi / 2.0),
             0  # undefined, but we have to return something - we'll return 0
     ]
     return convertedExpression


### PR DESCRIPTION
Added support for atan2 for geostyler->mapbox

Geostyler supports atan2 (https://geostyler.github.io/geostyler-style/docs/master/interfaces/Fatan2.html). But unfortunately, mapbox seems not, therefore we added a conversion between atan2 and a piecewise implementation using atan as described in https://en.wikipedia.org/wiki/Atan2#Definition%20and%20computation. This seems to work.

Testing example: 

Angle of the arrow based on attribute values in QGIS. Expression: atan2("q_out_x_sum", "q_out_y_sum") * 180 / 3.14159265358979

<img width="827" height="475" alt="image" src="https://github.com/user-attachments/assets/eda48132-84fd-420d-b93a-fe91407a1bc4" />

<img width="856" height="458" alt="image" src="https://github.com/user-attachments/assets/b7797faa-9bd6-4519-b79c-8475e3b2de06" />
