### PR TITLE
MapBoxGL: basic support for marker lines

### DIFF
--- a/src/bridgestyle/mapboxgl/fromgeostyler.py
+++ b/src/bridgestyle/mapboxgl/fromgeostyler.py
@@ -479,7 +479,7 @@ def _markSymbolizer(sl):
         paint = {
             "icon-image": name,
             "icon-rotate": rotation,
-            "icon-size": size,
+            "icon-size": size
         }
         return {"type": "symbol", "layout": paint}
 

--- a/src/bridgestyle/mapboxgl/fromgeostyler.py
+++ b/src/bridgestyle/mapboxgl/fromgeostyler.py
@@ -389,9 +389,25 @@ def _lineSymbolizer(sl, graphicStrokeLayer=0):
 
     paint = {}
     layout = {}
+    graphicStrokeLayers = []
     if graphicStroke is not None:
-        _warnings.append("Marker lines not supported for Mapbox GL conversion")
-        # TODO
+        for marker in graphicStroke:
+            markerPaint = {}
+            markerLayout = {}
+            kind = marker.get("kind")
+            if kind == "Mark":
+                markerLayout["symbol-placement"] = "line-center"
+                markerLayout["icon-image"] = marker.get("spriteName")
+                markerLayout["icon-size"] = marker.get("size", 1) / 64
+                markerLayout["icon-rotate"] = marker.get("rotate", 0.0)
+                markerLayout["icon-rotation-alignment"] = "viewport"
+                markerLayout["icon-allow-overlap"] = True
+                markerPaint["icon-color"] = marker.get("color")
+                markerPaint["icon-opacity"] = marker.get("opacity", 1)
+            else:
+                _warnings.append(f"Unsupported graphicStroke marker kind '{kind}'")
+                continue
+            graphicStrokeLayers.append({"type": "symbol", "layout": markerLayout, "paint": markerPaint})
 
     if color is None:
         paint["visibility"] = "none"
@@ -406,11 +422,15 @@ def _lineSymbolizer(sl, graphicStrokeLayer=0):
     if offset is not None:
         paint["line-offset"] = offset
 
-    return {
+    lineLayer = {
         "type": "line",
         "paint": paint,
         "layout": layout
     }
+
+    if graphicStrokeLayers:
+        return [lineLayer] + graphicStrokeLayers
+    return lineLayer
 
 
 def number(string):
@@ -455,13 +475,16 @@ def _markSymbolizer(sl):
         name = os.path.splitext(shape)[0]
         rotation = _symbolProperty(sl, "rotate")
         size = _symbolProperty(sl, "size", 16) / 64.0
+        color = _symbolProperty(sl, "color")
 
-        paint = {
+        layout = {
             "icon-image": name,
             "icon-rotate": rotation,
-            "icon-size": size
+            "icon-size": size,
+            
         }
-        return {"type": "symbol", "layout": paint}
+        paint = {"icon-color": color}
+        return {"type": "symbol", "layout": layout, "paint": paint}
 
     # Shape is a circle (or symbol should be rendered like that)
     size = _symbolProperty(sl, "size")

--- a/src/bridgestyle/mapboxgl/fromgeostyler.py
+++ b/src/bridgestyle/mapboxgl/fromgeostyler.py
@@ -475,16 +475,13 @@ def _markSymbolizer(sl):
         name = os.path.splitext(shape)[0]
         rotation = _symbolProperty(sl, "rotate")
         size = _symbolProperty(sl, "size", 16) / 64.0
-        color = _symbolProperty(sl, "color")
 
-        layout = {
+        paint = {
             "icon-image": name,
             "icon-rotate": rotation,
             "icon-size": size,
-            
         }
-        paint = {"icon-color": color}
-        return {"type": "symbol", "layout": layout, "paint": paint}
+        return {"type": "symbol", "layout": paint}
 
     # Shape is a circle (or symbol should be rendered like that)
     size = _symbolProperty(sl, "size")


### PR DESCRIPTION
Added some basic support for marker lines. Symbolizers' graphicStroke is not converted as well.

QGIS

<img width="831" height="378" alt="image" src="https://github.com/user-attachments/assets/d3edebd0-63e2-4e4e-9396-e01e65c225ee" />

Mapbox GL

<img width="1038" height="386" alt="image" src="https://github.com/user-attachments/assets/22d172ea-14a2-4dd3-90f3-cfe1402b8d83" />
